### PR TITLE
feat(mocks): Randomize player and agent assignments per match

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -6,8 +6,8 @@ const axios = require('axios');
 require('dotenv').config();
 const { MongoClient, ServerApiVersion } = require('mongodb');
 const { spawn } = require('child_process');
-const fs = require('fs'); // Módulo de arquivos adicionado
-const path = require('path'); // Módulo de caminhos adicionado
+const fs = require('fs');
+const path = require('path');
 
 // Inicialização do Express
 const app = express();
@@ -16,23 +16,23 @@ const PORT = process.env.PORT || 5000;
 // --- CONFIGURAÇÃO COMPLETA DO MONGODB ---
 const uri = process.env.MONGODB_URI;
 const client = new MongoClient(uri, {
-  serverApi: {
-    version: ServerApiVersion.v1,
-    strict: true,
-    deprecationErrors: true,
-  }
+  serverApi: {
+    version: ServerApiVersion.v1,
+    strict: true,
+    deprecationErrors: true,
+  }
 });
 let db;
 
 async function connectDB() {
-  try {
-    await client.connect();
-    db = client.db("valorant-stats");
-    console.log("Conectado ao MongoDB Atlas com sucesso!");
-  } catch (err) {
-    console.error("Falha ao conectar ao MongoDB", err);
-    process.exit(1);
-  }
+  try {
+    await client.connect();
+    db = client.db("valorant-stats");
+    console.log("Conectado ao MongoDB Atlas com sucesso!");
+  } catch (err) {
+    console.error("Falha ao conectar ao MongoDB", err);
+    process.exit(1);
+  }
 }
 // --- FIM DA CONFIGURAÇÃO ---
 
@@ -40,175 +40,66 @@ async function connectDB() {
 app.use(cors());
 app.use(express.json());
 
-// --- ROTAS DA APLICAÇÃO ---
+// --- ROTAS GERAIS E DE AUTENTICAÇÃO ---
 
-// Rota raiz
 app.get('/', (req, res) => {
-    res.send('Servidor rodando com MongoDB!');
+    res.send('Servidor rodando com MongoDB!');
 });
 
-// Rota de autenticação da Riot
 app.get('/auth/riot', (req, res) => {
-  const clientId = process.env.RIOT_CLIENT_ID || 'ID_AINDA_NAO_CONFIGURADO';
-  const redirectUri = process.env.REDIRECT_URI || 'https://valorant-backend.onrender.com/auth/riot/callback';
-  const authorizationUri = `https://auth.riotgames.com/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=openid`;
-  res.redirect(authorizationUri);
+  const clientId = process.env.RIOT_CLIENT_ID || 'ID_AINDA_NAO_CONFIGURADO';
+  const redirectUri = process.env.REDIRECT_URI || 'https://valorant-backend.onrender.com/auth/riot/callback';
+  const authorizationUri = `https://auth.riotgames.com/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code&scope=openid`;
+  res.redirect(authorizationUri);
 });
 
-// Rota de callback com o "interruptor"
 app.get('/auth/riot/callback', async (req, res) => {
-  console.log("-> Rota de callback acionada!");
-  if (process.env.USE_MOCK_DATA === 'true') {
-    console.log("-> MODO FICTÍCIO ATIVADO. Salvando dados de teste.");
-    try {
-      const mockUserData = { puuid: `PUUID_FICTICIO_${Date.now()}`, gameName: 'Jogador Fictício', tagLine: 'MOCK' };
-      await db.collection('users').updateOne({ puuid: mockUserData.puuid }, { $set: mockUserData }, { upsert: true });
-      console.log(`-> Usuário fictício salvo com sucesso!`);
-      res.redirect('https://valorant-frontend.onrender.com/dashboard');
-    } catch (error) {
-      console.error("-> ERRO ao salvar dados fictícios:", error);
-      res.redirect('https://valorant-frontend.com/?error=mock_db_failed');
-    }
-  } else {
-    // A lógica para dados reais continua aqui, pronta para o futuro
-    res.send("Modo real ativado, mas ainda não implementado.");
-  }
+  console.log("-> Rota de callback acionada!");
+  if (process.env.USE_MOCK_DATA === 'true') {
+    console.log("-> MODO FICTÍCIO ATIVADO. Salvando dados de teste.");
+    try {
+      const mockUserData = { puuid: `PUUID_FICTICIO_${Date.now()}`, gameName: 'Jogador Fictício', tagLine: 'MOCK' };
+      await db.collection('users').updateOne({ puuid: mockUserData.puuid }, { $set: mockUserData }, { upsert: true });
+      console.log(`-> Usuário fictício salvo com sucesso!`);
+      res.redirect('https://valorant-frontend.onrender.com/dashboard');
+    } catch (error) {
+      console.error("-> ERRO ao salvar dados fictícios:", error);
+      res.redirect('https://valorant-frontend.com/?error=mock_db_failed');
+    }
+  } else {
+    res.send("Modo real ativado, mas ainda não implementado.");
+  }
 });
 
-// NOVA ROTA PARA ACIONAR O MODELO DE CLUSTERING
-app.get('/api/run-clustering', (req, res) => {
-  console.log("-> Acionando o script de clustering em Python...");
-  const pythonProcess = spawn('python', ['cluster_model.py']);
-  pythonProcess.stdout.on('data', (data) => console.log(`[Python Script]: ${data}`));
-  pythonProcess.stderr.on('data', (data) => console.error(`[Python Script ERROR]: ${data}`));
-  pythonProcess.on('close', (code) => {
-    if (code === 0) {
-      console.log("-> Script de clustering finalizado com sucesso.");
-      res.status(200).send("Processo de clustering concluído com sucesso!");
-    } else {
-      console.log(`-> Script de clustering finalizado com erro, código: ${code}`);
-      res.status(500).send("Ocorreu um erro durante o processo de clustering.");
-    }
-  });
+// --- ROTAS PARA DADOS FICTÍCIOS (MOCKS) ---
+
+app.get('/api/match-history', (req, res) => {
+  try {
+    const historyPath = path.join(__dirname, 'mocks', 'match-history.json');
+    if (fs.existsSync(historyPath)) {
+      const historyData = JSON.parse(fs.readFileSync(historyPath, 'utf-8'));
+      res.status(200).json(historyData);
+    } else {
+      res.status(404).json({ message: "Arquivo de histórico não encontrado." });
+    }
+  } catch (error) {
+    console.error("ERRO ao buscar histórico de partidas:", error);
+    res.status(500).json({ message: "Erro interno do servidor." });
+  }
 });
 
-// ROTA PARA BUSCAR CONTEÚDO (AGENTES)
-app.get('/api/content', async (req, res) => {
-  try {
-    console.log("-> Rota /api/content acionada!");
-    const apiKey = process.env.RIOT_API_KEY;
-    if (!apiKey) throw new Error("A chave da API da Riot não foi configurada no .env");
-    const riotApiUrl = `https://br.api.riotgames.com/val/content/v1/contents?locale=pt-BR`;
-    const communityApiUrl = `https://valorant-api.com/v1/agents?language=pt-BR&isPlayableCharacter=true`;
-    const [riotResponse, communityResponse] = await Promise.all([
-      axios.get(riotApiUrl, { headers: { "X-Riot-Token": apiKey } }),
-      axios.get(communityApiUrl)
-    ]);
-    const riotCharacters = riotResponse.data.characters;
-    const communityAgentsData = communityResponse.data.data;
-    const playableAgentNames = riotCharacters
-      .filter(character => character.name !== "Null UI Data!")
-      .map(agent => agent.name.toLowerCase());
-    const finalAgentList = communityAgentsData
-      .filter(agent => playableAgentNames.includes(agent.displayName.toLowerCase()))
-      .map(agent => ({ id: agent.uuid, name: agent.displayName, displayIcon: agent.displayIcon }));
-    console.log(`-> ${finalAgentList.length} agentes enriquecidos com ícones encontrados.`);
-    res.status(200).json(finalAgentList);
-  } catch (error) {
-    console.error("-> ERRO ao buscar conteúdo enriquecido:", error.response ? error.response.data : error.message);
-    res.status(500).json({ message: "Erro ao buscar dados dos agentes." });
-  }
-});
-
-// ROTA PARA "SEMEAR" O BANCO DE DADOS
-app.get('/api/seed-database', async (req, res) => {
-  try {
-    console.log("-> Semeando o banco de dados com dados fictícios...");
-    const { mockMatches } = require('../client/src/shared/mockMatchData');
-    const matchesCollection = db.collection('matches');
-    await matchesCollection.deleteMany({});
-    const result = await matchesCollection.insertMany(mockMatches);
-    console.log(`-> ${result.insertedCount} partidas inseridas com sucesso!`);
-    res.status(200).send(`${result.insertedCount} partidas fictícias foram inseridas no banco de dados com sucesso!`);
-  } catch (error) {
-    console.error("-> ERRO ao semear o banco de dados:", error);
-    res.status(500).send("Ocorreu um erro ao semear o banco de dados.");
-  }
-});
-
-// ROTA PARA BUSCAR TODAS AS PARTIDAS DO DB
-app.get('/api/matches', async (req, res) => {
-  try {
-    const matchesCollection = db.collection('matches');
-    const allMatches = await matchesCollection.find({}).toArray();
-    if (allMatches.length === 0) return res.status(404).json({ message: "Nenhuma partida encontrada no banco de dados." });
-    console.log(`-> Enviando ${allMatches.length} partidas do MongoDB.`);
-    res.status(200).json(allMatches);
-  } catch (error) {
-    console.error("-> ERRO ao buscar partidas do DB:", error);
-    res.status(500).json({ message: "Ocorreu um erro ao buscar as partidas." });
-  }
-});
-
-// ROTA PARA ACIONAR O MODELO DE CLASSIFICAÇÃO
-app.get('/api/run-classifier', (req, res) => {
-  console.log("-> Acionando o script de classificação em Python...");
-  const pythonProcess = spawn('python', ['classifier_model.py']);
-  let resultData = '';
-  pythonProcess.stdout.on('data', (data) => resultData += data.toString());
-  pythonProcess.stderr.on('data', (data) => console.error(`[Python Script ERROR]: ${data}`));
-  pythonProcess.on('close', (code) => {
-    if (code === 0) {
-      console.log("-> Script de classificação finalizado com sucesso.");
-      res.status(200).json(JSON.parse(resultData));
-    } else {
-      console.log(`-> Script de classificação finalizado com erro, código: ${code}`);
-      res.status(500).send("Ocorreu um erro durante o processo de classificação.");
-    }
-  });
-});
-
-// ROTA PARA PREVISÃO EM TEMPO REAL
-app.post('/api/predict', (req, res) => {
-  console.log("-> Recebida requisição de previsão com os dados:", req.body);
-  const dataString = JSON.stringify(req.body);
-  const pythonProcess = spawn('python', ['predict_model.py', dataString]);
-  let resultData = '';
-  pythonProcess.stdout.on('data', (data) => resultData += data.toString());
-  pythonProcess.stderr.on('data', (data) => console.error(`[Python Predict ERROR]: ${data}`));
-  pythonProcess.on('close', (code) => {
-    if (code === 0) {
-      console.log("-> Previsão realizada com sucesso:", resultData);
-      res.status(200).json(JSON.parse(resultData));
-    } else {
-      res.status(500).send("Erro durante a previsão.");
-    }
-  });
-});
-
-
-// --- MUDANÇA PRINCIPAL ---
-// ROTA ATUALIZADA para buscar uma partida específica por ID
 app.get('/api/detailed-match/:matchId', (req, res) => {
   try {
-    // 1. Pega o ID da partida a partir dos parâmetros da URL (ex: "match-1")
     const { matchId } = req.params;
-    
-    // 2. Medida de segurança: Garante que o ID é simples para evitar ataques
     if (!/^[a-zA-Z0-9-]+$/.test(matchId)) {
       return res.status(400).json({ message: "ID de partida inválido." });
     }
-
-    // 3. Constrói o caminho para o arquivo JSON correspondente (ex: .../mocks/match-1.json)
     const filePath = path.join(__dirname, 'mocks', `${matchId}.json`);
-
-    // 4. Verifica se o arquivo realmente existe antes de tentar ler
     if (fs.existsSync(filePath)) {
       const matchData = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
       console.log(`-> Enviando dados para a partida: ${matchId}`);
       res.status(200).json(matchData);
     } else {
-      // Se o arquivo não for encontrado, envia um erro 404
       console.log(`-> Partida não encontrada: ${matchId}`);
       res.status(404).json({ message: "Partida não encontrada." });
     }
@@ -219,10 +110,118 @@ app.get('/api/detailed-match/:matchId', (req, res) => {
 });
 
 
+// --- ROTAS DE DADOS E MODELOS DE ML ---
+
+app.get('/api/run-clustering', (req, res) => {
+  console.log("-> Acionando o script de clustering em Python...");
+  const pythonProcess = spawn('python', ['cluster_model.py']);
+  pythonProcess.stdout.on('data', (data) => console.log(`[Python Script]: ${data}`));
+  pythonProcess.stderr.on('data', (data) => console.error(`[Python Script ERROR]: ${data}`));
+  pythonProcess.on('close', (code) => {
+    if (code === 0) {
+      console.log("-> Script de clustering finalizado com sucesso.");
+      res.status(200).send("Processo de clustering concluído com sucesso!");
+    } else {
+      console.log(`-> Script de clustering finalizado com erro, código: ${code}`);
+      res.status(500).send("Ocorreu um erro durante o processo de clustering.");
+    }
+  });
+});
+
+app.get('/api/content', async (req, res) => {
+  try {
+    console.log("-> Rota /api/content acionada!");
+    const apiKey = process.env.RIOT_API_KEY;
+    if (!apiKey) throw new Error("A chave da API da Riot não foi configurada no .env");
+    const riotApiUrl = `https://br.api.riotgames.com/val/content/v1/contents?locale=pt-BR`;
+    const communityApiUrl = `https://valorant-api.com/v1/agents?language=pt-BR&isPlayableCharacter=true`;
+    const [riotResponse, communityResponse] = await Promise.all([
+      axios.get(riotApiUrl, { headers: { "X-Riot-Token": apiKey } }),
+      axios.get(communityApiUrl)
+    ]);
+    const riotCharacters = riotResponse.data.characters;
+    const communityAgentsData = communityResponse.data.data;
+    const playableAgentNames = riotCharacters
+      .filter(character => character.name !== "Null UI Data!")
+      .map(agent => agent.name.toLowerCase());
+    const finalAgentList = communityAgentsData
+      .filter(agent => playableAgentNames.includes(agent.displayName.toLowerCase()))
+      .map(agent => ({ id: agent.uuid, name: agent.displayName, displayIcon: agent.displayIcon }));
+    console.log(`-> ${finalAgentList.length} agentes enriquecidos com ícones encontrados.`);
+    res.status(200).json(finalAgentList);
+  } catch (error) {
+    console.error("-> ERRO ao buscar conteúdo enriquecido:", error.response ? error.response.data : error.message);
+    res.status(500).json({ message: "Erro ao buscar dados dos agentes." });
+  }
+});
+
+app.get('/api/seed-database', async (req, res) => {
+  try {
+    console.log("-> Semeando o banco de dados com dados fictícios...");
+    const { mockMatches } = require('../client/src/shared/mockMatchData');
+    const matchesCollection = db.collection('matches');
+    await matchesCollection.deleteMany({});
+    const result = await matchesCollection.insertMany(mockMatches);
+    console.log(`-> ${result.insertedCount} partidas inseridas com sucesso!`);
+    res.status(200).send(`${result.insertedCount} partidas fictícias foram inseridas no banco de dados com sucesso!`);
+  } catch (error) {
+    console.error("-> ERRO ao semear o banco de dados:", error);
+    res.status(500).send("Ocorreu um erro ao semear o banco de dados.");
+  }
+});
+
+app.get('/api/matches', async (req, res) => {
+  try {
+    const matchesCollection = db.collection('matches');
+    const allMatches = await matchesCollection.find({}).toArray();
+    if (allMatches.length === 0) return res.status(404).json({ message: "Nenhuma partida encontrada no banco de dados." });
+    console.log(`-> Enviando ${allMatches.length} partidas do MongoDB.`);
+    res.status(200).json(allMatches);
+  } catch (error) {
+    console.error("-> ERRO ao buscar partidas do DB:", error);
+    res.status(500).json({ message: "Ocorreu um erro ao buscar as partidas." });
+  }
+});
+
+app.get('/api/run-classifier', (req, res) => {
+  console.log("-> Acionando o script de classificação em Python...");
+  const pythonProcess = spawn('python', ['classifier_model.py']);
+  let resultData = '';
+  pythonProcess.stdout.on('data', (data) => resultData += data.toString());
+  pythonProcess.stderr.on('data', (data) => console.error(`[Python Script ERROR]: ${data}`));
+  pythonProcess.on('close', (code) => {
+    if (code === 0) {
+      console.log("-> Script de classificação finalizado com sucesso.");
+      res.status(200).json(JSON.parse(resultData));
+    } else {
+      console.log(`-> Script de classificação finalizado com erro, código: ${code}`);
+      res.status(500).send("Ocorreu um erro durante o processo de classificação.");
+    }
+  });
+});
+
+app.post('/api/predict', (req, res) => {
+  console.log("-> Recebida requisição de previsão com os dados:", req.body);
+  const dataString = JSON.stringify(req.body);
+  const pythonProcess = spawn('python', ['predict_model.py', dataString]);
+  let resultData = '';
+  pythonProcess.stdout.on('data', (data) => resultData += data.toString());
+  pythonProcess.stderr.on('data', (data) => console.error(`[Python Predict ERROR]: ${data}`));
+  pythonProcess.on('close', (code) => {
+    if (code === 0) {
+      console.log("-> Previsão realizada com sucesso:", resultData);
+      res.status(200).json(JSON.parse(resultData));
+    } else {
+      res.status(500).send("Erro durante a previsão.");
+    }
+  });
+});
+
+
 // --- INICIALIZAÇÃO DO SERVIDOR ---
 connectDB().then(() => {
-  app.listen(PORT, () => {
-      console.log(`Servidor escutando na porta ${PORT}`);
-  });
+  app.listen(PORT, () => {
+      console.log(`Servidor escutando na porta ${PORT}`);
+  });
 });
 

--- a/server/mocks/match-1.json
+++ b/server/mocks/match-1.json
@@ -2,7 +2,7 @@
   "matchInfo": {
     "matchId": "match-1",
     "mapId": "/Game/Maps/Ascent/Ascent",
-    "gameLengthMillis": 2165487,
+    "gameLengthMillis": 2341970,
     "gameStartMillis": 1725154800000,
     "provisioningFlowId": "Competitive",
     "isCompleted": true,
@@ -10,268 +10,268 @@
   },
   "players": [
     {
-      "puuid": "puuid-player-0-3225",
-      "gameName": "PlayerOne",
-      "tagLine": "BR1",
-      "teamId": "Blue",
-      "partyId": "party-4",
-      "characterId": "Jett",
-      "stats": {
-        "kills": 9,
-        "deaths": 20,
-        "assists": 14,
-        "score": 2544,
-        "playtimeMillis": 2060288,
-        "damage": [
-          {
-            "damage": 2538
-          }
-        ],
-        "economy": {
-          "spent": 85942,
-          "loadoutValue": 3582
-        }
-      },
-      "competitiveTier": 19
-    },
-    {
-      "puuid": "puuid-player-1-1277",
-      "gameName": "Ninja",
-      "tagLine": "NA1",
-      "teamId": "Blue",
-      "partyId": "party-1",
-      "characterId": "Phoenix",
-      "stats": {
-        "kills": 15,
-        "deaths": 13,
-        "assists": 14,
-        "score": 3387,
-        "playtimeMillis": 2105353,
-        "damage": [
-          {
-            "damage": 5325
-          }
-        ],
-        "economy": {
-          "spent": 92976,
-          "loadoutValue": 3100
-        }
-      },
-      "competitiveTier": 19
-    },
-    {
-      "puuid": "puuid-player-2-2572",
+      "puuid": "puuid-Shroud-3222",
       "gameName": "Shroud",
       "tagLine": "KR1",
       "teamId": "Blue",
-      "partyId": "party-1",
+      "partyId": "party-3",
       "characterId": "Sage",
       "stats": {
-        "kills": 20,
+        "kills": 19,
         "deaths": 13,
         "assists": 6,
-        "score": 3640,
-        "playtimeMillis": 2123833,
+        "score": 3142,
+        "playtimeMillis": 1982008,
         "damage": [
           {
-            "damage": 5875
+            "damage": 2496
           }
         ],
         "economy": {
-          "spent": 71260,
-          "loadoutValue": 3823
+          "spent": 86892,
+          "loadoutValue": 4181
+        }
+      },
+      "competitiveTier": 22
+    },
+    {
+      "puuid": "puuid-Ninja-7513",
+      "gameName": "Ninja",
+      "tagLine": "KR1",
+      "teamId": "Blue",
+      "partyId": "party-1",
+      "characterId": "Cypher",
+      "stats": {
+        "kills": 22,
+        "deaths": 16,
+        "assists": 15,
+        "score": 4375,
+        "playtimeMillis": 2079512,
+        "damage": [
+          {
+            "damage": 3510
+          }
+        ],
+        "economy": {
+          "spent": 67524,
+          "loadoutValue": 3582
         }
       },
       "competitiveTier": 25
     },
     {
-      "puuid": "puuid-player-3-2281",
-      "gameName": "Tenz",
-      "tagLine": "KR1",
+      "puuid": "puuid-Ace-4855",
+      "gameName": "Ace",
+      "tagLine": "NA1",
       "teamId": "Blue",
       "partyId": "party-2",
-      "characterId": "Sova",
-      "stats": {
-        "kills": 19,
-        "deaths": 19,
-        "assists": 15,
-        "score": 3835,
-        "playtimeMillis": 2076332,
-        "damage": [
-          {
-            "damage": 4375
-          }
-        ],
-        "economy": {
-          "spent": 69222,
-          "loadoutValue": 3585
-        }
-      },
-      "competitiveTier": 19
-    },
-    {
-      "puuid": "puuid-player-4-1779",
-      "gameName": "ScreaM",
-      "tagLine": "LAS",
-      "teamId": "Blue",
-      "partyId": "party-3",
       "characterId": "Brimstone",
       "stats": {
-        "kills": 8,
-        "deaths": 12,
-        "assists": 3,
-        "score": 1581,
-        "playtimeMillis": 2142786,
+        "kills": 23,
+        "deaths": 20,
+        "assists": 8,
+        "score": 3913,
+        "playtimeMillis": 1882613,
         "damage": [
           {
-            "damage": 5725
+            "damage": 2442
           }
         ],
         "economy": {
-          "spent": 71464,
-          "loadoutValue": 3255
+          "spent": 89155,
+          "loadoutValue": 4758
         }
       },
-      "competitiveTier": 18
+      "competitiveTier": 15
     },
     {
-      "puuid": "puuid-player-5-2010",
+      "puuid": "puuid-Mixwell-7972",
       "gameName": "Mixwell",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "partyId": "party-5",
+      "characterId": "Sova",
+      "stats": {
+        "kills": 12,
+        "deaths": 14,
+        "assists": 7,
+        "score": 2102,
+        "playtimeMillis": 1865554,
+        "damage": [
+          {
+            "damage": 2740
+          }
+        ],
+        "economy": {
+          "spent": 97639,
+          "loadoutValue": 4776
+        }
+      },
+      "competitiveTier": 22
+    },
+    {
+      "puuid": "puuid-Hiko-7160",
+      "gameName": "Hiko",
       "tagLine": "LAS",
-      "teamId": "Red",
+      "teamId": "Blue",
       "partyId": "party-5",
       "characterId": "Viper",
       "stats": {
-        "kills": 28,
-        "deaths": 14,
-        "assists": 15,
-        "score": 5382,
-        "playtimeMillis": 2130517,
+        "kills": 11,
+        "deaths": 13,
+        "assists": 2,
+        "score": 1781,
+        "playtimeMillis": 2359374,
         "damage": [
           {
-            "damage": 3611
+            "damage": 5412
           }
         ],
         "economy": {
-          "spent": 61776,
-          "loadoutValue": 3601
+          "spent": 89490,
+          "loadoutValue": 4751
         }
       },
-      "competitiveTier": 23
+      "competitiveTier": 20
     },
     {
-      "puuid": "puuid-player-6-4800",
-      "gameName": "Hiko",
-      "tagLine": "NA1",
+      "puuid": "puuid-PlayerOne-5052",
+      "gameName": "PlayerOne",
+      "tagLine": "LAS",
       "teamId": "Red",
-      "partyId": "party-1",
-      "characterId": "Omen",
+      "partyId": "party-5",
+      "characterId": "Jett",
       "stats": {
-        "kills": 6,
-        "deaths": 17,
-        "assists": 9,
-        "score": 937,
-        "playtimeMillis": 2078482,
+        "kills": 13,
+        "deaths": 11,
+        "assists": 15,
+        "score": 2921,
+        "playtimeMillis": 2130504,
         "damage": [
           {
-            "damage": 3762
+            "damage": 5250
           }
         ],
         "economy": {
-          "spent": 69815,
-          "loadoutValue": 4655
+          "spent": 83935,
+          "loadoutValue": 3921
         }
       },
-      "competitiveTier": 17
+      "competitiveTier": 25
     },
     {
-      "puuid": "puuid-player-7-8026",
-      "gameName": "Steel",
+      "puuid": "puuid-Tenz-4672",
+      "gameName": "Tenz",
       "tagLine": "EUW",
       "teamId": "Red",
       "partyId": "party-3",
-      "characterId": "Cypher",
+      "characterId": "Killjoy",
       "stats": {
-        "kills": 16,
-        "deaths": 16,
-        "assists": 13,
-        "score": 2812,
-        "playtimeMillis": 2102911,
+        "kills": 12,
+        "deaths": 17,
+        "assists": 6,
+        "score": 1625,
+        "playtimeMillis": 1836059,
         "damage": [
           {
-            "damage": 2760
+            "damage": 4176
           }
         ],
         "economy": {
-          "spent": 76441,
-          "loadoutValue": 3541
+          "spent": 92217,
+          "loadoutValue": 4726
         }
       },
-      "competitiveTier": 16
+      "competitiveTier": 15
     },
     {
-      "puuid": "puuid-player-8-8016",
-      "gameName": "Ace",
+      "puuid": "puuid-Sacy-9121",
+      "gameName": "Sacy",
+      "tagLine": "NA1",
+      "teamId": "Red",
+      "partyId": "party-5",
+      "characterId": "Omen",
+      "stats": {
+        "kills": 28,
+        "deaths": 16,
+        "assists": 15,
+        "score": 5282,
+        "playtimeMillis": 1874942,
+        "damage": [
+          {
+            "damage": 4600
+          }
+        ],
+        "economy": {
+          "spent": 64057,
+          "loadoutValue": 4246
+        }
+      },
+      "competitiveTier": 20
+    },
+    {
+      "puuid": "puuid-ScreaM-6455",
+      "gameName": "ScreaM",
       "tagLine": "KR1",
       "teamId": "Red",
       "partyId": "party-2",
       "characterId": "Reyna",
       "stats": {
-        "kills": 6,
-        "deaths": 20,
-        "assists": 16,
-        "score": 1886,
-        "playtimeMillis": 2047838,
+        "kills": 22,
+        "deaths": 13,
+        "assists": 12,
+        "score": 4238,
+        "playtimeMillis": 2136452,
         "damage": [
           {
-            "damage": 2040
+            "damage": 5736
           }
         ],
         "economy": {
-          "spent": 85710,
-          "loadoutValue": 3031
+          "spent": 78601,
+          "loadoutValue": 3795
         }
       },
-      "competitiveTier": 25
+      "competitiveTier": 21
     },
     {
-      "puuid": "puuid-player-9-4986",
-      "gameName": "Sacy",
-      "tagLine": "KR1",
+      "puuid": "puuid-Steel-2109",
+      "gameName": "Steel",
+      "tagLine": "BR1",
       "teamId": "Red",
-      "partyId": "party-1",
-      "characterId": "Killjoy",
+      "partyId": "party-4",
+      "characterId": "Phoenix",
       "stats": {
-        "kills": 23,
-        "deaths": 10,
-        "assists": 7,
-        "score": 3382,
-        "playtimeMillis": 2024655,
+        "kills": 11,
+        "deaths": 19,
+        "assists": 13,
+        "score": 2563,
+        "playtimeMillis": 1836145,
         "damage": [
           {
-            "damage": 3674
+            "damage": 2740
           }
         ],
         "economy": {
-          "spent": 62568,
-          "loadoutValue": 3706
+          "spent": 88913,
+          "loadoutValue": 4636
         }
       },
-      "competitiveTier": 23
+      "competitiveTier": 18
     }
   ],
   "teams": [
     {
       "teamId": "Blue",
-      "won": true,
-      "roundsWon": 13,
-      "roundsPlayed": 22
+      "won": false,
+      "roundsWon": 11,
+      "roundsPlayed": 24
     },
     {
       "teamId": "Red",
-      "won": false,
-      "roundsWon": 9,
-      "roundsPlayed": 22
+      "won": true,
+      "roundsWon": 13,
+      "roundsPlayed": 24
     }
   ],
   "roundResults": [
@@ -285,7 +285,7 @@
     },
     {
       "roundNum": 3,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 4,
@@ -293,7 +293,7 @@
     },
     {
       "roundNum": 5,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 6,
@@ -301,15 +301,15 @@
     },
     {
       "roundNum": 7,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 8,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 9,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 10,
@@ -321,7 +321,7 @@
     },
     {
       "roundNum": 12,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 13,
@@ -329,15 +329,15 @@
     },
     {
       "roundNum": 14,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 15,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 16,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 17,
@@ -361,7 +361,15 @@
     },
     {
       "roundNum": 22,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
+    },
+    {
+      "roundNum": 23,
+      "winningTeam": "Red"
+    },
+    {
+      "roundNum": 24,
+      "winningTeam": "Red"
     }
   ]
 }

--- a/server/mocks/match-2.json
+++ b/server/mocks/match-2.json
@@ -1,8 +1,8 @@
 {
   "matchInfo": {
     "matchId": "match-2",
-    "mapId": "/Game/Maps/Ascent/Ascent",
-    "gameLengthMillis": 2165487,
+    "mapId": "/Game/Maps/Bind/Bind",
+    "gameLengthMillis": 2284195,
     "gameStartMillis": 1725154800000,
     "provisioningFlowId": "Competitive",
     "isCompleted": true,
@@ -10,268 +10,268 @@
   },
   "players": [
     {
-      "puuid": "puuid-player-0-3508",
-      "gameName": "PlayerOne",
+      "puuid": "puuid-Ace-1326",
+      "gameName": "Ace",
       "tagLine": "NA1",
       "teamId": "Blue",
-      "partyId": "party-1",
-      "characterId": "Jett",
+      "partyId": "party-3",
+      "characterId": "Cypher",
       "stats": {
-        "kills": 21,
-        "deaths": 16,
-        "assists": 14,
-        "score": 3918,
-        "playtimeMillis": 2116226,
+        "kills": 27,
+        "deaths": 12,
+        "assists": 7,
+        "score": 4870,
+        "playtimeMillis": 1813701,
         "damage": [
           {
-            "damage": 2970
+            "damage": 4324
           }
         ],
         "economy": {
-          "spent": 88507,
-          "loadoutValue": 4231
+          "spent": 79202,
+          "loadoutValue": 3666
         }
       },
-      "competitiveTier": 16
+      "competitiveTier": 19
     },
     {
-      "puuid": "puuid-player-1-3318",
-      "gameName": "Ninja",
-      "tagLine": "LAS",
-      "teamId": "Blue",
-      "partyId": "party-5",
-      "characterId": "Phoenix",
-      "stats": {
-        "kills": 26,
-        "deaths": 20,
-        "assists": 12,
-        "score": 4241,
-        "playtimeMillis": 2023842,
-        "damage": [
-          {
-            "damage": 2204
-          }
-        ],
-        "economy": {
-          "spent": 77491,
-          "loadoutValue": 4642
-        }
-      },
-      "competitiveTier": 15
-    },
-    {
-      "puuid": "puuid-player-2-7826",
-      "gameName": "Shroud",
-      "tagLine": "EUW",
-      "teamId": "Blue",
-      "partyId": "party-5",
-      "characterId": "Sage",
-      "stats": {
-        "kills": 24,
-        "deaths": 22,
-        "assists": 17,
-        "score": 4215,
-        "playtimeMillis": 2140792,
-        "damage": [
-          {
-            "damage": 2520
-          }
-        ],
-        "economy": {
-          "spent": 88504,
-          "loadoutValue": 4912
-        }
-      },
-      "competitiveTier": 25
-    },
-    {
-      "puuid": "puuid-player-3-7480",
-      "gameName": "Tenz",
-      "tagLine": "KR1",
-      "teamId": "Blue",
-      "partyId": "party-1",
-      "characterId": "Sova",
-      "stats": {
-        "kills": 21,
-        "deaths": 14,
-        "assists": 12,
-        "score": 3332,
-        "playtimeMillis": 2154053,
-        "damage": [
-          {
-            "damage": 4439
-          }
-        ],
-        "economy": {
-          "spent": 69404,
-          "loadoutValue": 3714
-        }
-      },
-      "competitiveTier": 24
-    },
-    {
-      "puuid": "puuid-player-4-1055",
-      "gameName": "ScreaM",
+      "puuid": "puuid-Mixwell-6837",
+      "gameName": "Mixwell",
       "tagLine": "KR1",
       "teamId": "Blue",
       "partyId": "party-2",
-      "characterId": "Brimstone",
+      "characterId": "Sova",
       "stats": {
-        "kills": 30,
-        "deaths": 15,
-        "assists": 2,
-        "score": 4544,
-        "playtimeMillis": 2056046,
+        "kills": 10,
+        "deaths": 20,
+        "assists": 12,
+        "score": 2489,
+        "playtimeMillis": 1917933,
         "damage": [
           {
-            "damage": 5625
+            "damage": 4944
           }
         ],
         "economy": {
-          "spent": 87518,
-          "loadoutValue": 3477
+          "spent": 94610,
+          "loadoutValue": 4813
         }
       },
-      "competitiveTier": 15
+      "competitiveTier": 23
     },
     {
-      "puuid": "puuid-player-5-8064",
-      "gameName": "Mixwell",
-      "tagLine": "EUW",
-      "teamId": "Red",
-      "partyId": "party-5",
-      "characterId": "Viper",
-      "stats": {
-        "kills": 13,
-        "deaths": 16,
-        "assists": 6,
-        "score": 2748,
-        "playtimeMillis": 2023696,
-        "damage": [
-          {
-            "damage": 5475
-          }
-        ],
-        "economy": {
-          "spent": 71366,
-          "loadoutValue": 3497
-        }
-      },
-      "competitiveTier": 16
-    },
-    {
-      "puuid": "puuid-player-6-4401",
+      "puuid": "puuid-Hiko-9808",
       "gameName": "Hiko",
       "tagLine": "KR1",
-      "teamId": "Red",
-      "partyId": "party-1",
-      "characterId": "Omen",
+      "teamId": "Blue",
+      "partyId": "party-2",
+      "characterId": "Jett",
       "stats": {
-        "kills": 30,
-        "deaths": 14,
-        "assists": 3,
-        "score": 4392,
-        "playtimeMillis": 2027319,
+        "kills": 18,
+        "deaths": 10,
+        "assists": 2,
+        "score": 3273,
+        "playtimeMillis": 2073072,
         "damage": [
           {
-            "damage": 6125
+            "damage": 3507
           }
         ],
         "economy": {
-          "spent": 83683,
-          "loadoutValue": 3668
+          "spent": 65209,
+          "loadoutValue": 4843
         }
       },
-      "competitiveTier": 25
+      "competitiveTier": 18
     },
     {
-      "puuid": "puuid-player-7-4020",
-      "gameName": "Steel",
-      "tagLine": "LAS",
-      "teamId": "Red",
+      "puuid": "puuid-Shroud-9901",
+      "gameName": "Shroud",
+      "tagLine": "EUW",
+      "teamId": "Blue",
       "partyId": "party-4",
-      "characterId": "Cypher",
+      "characterId": "Viper",
       "stats": {
-        "kills": 16,
-        "deaths": 20,
-        "assists": 16,
-        "score": 2763,
-        "playtimeMillis": 2163492,
+        "kills": 12,
+        "deaths": 14,
+        "assists": 5,
+        "score": 1919,
+        "playtimeMillis": 2168590,
         "damage": [
           {
-            "damage": 3780
+            "damage": 3819
           }
         ],
         "economy": {
-          "spent": 89755,
-          "loadoutValue": 3728
+          "spent": 67376,
+          "loadoutValue": 4423
         }
       },
       "competitiveTier": 17
     },
     {
-      "puuid": "puuid-player-8-8079",
-      "gameName": "Ace",
+      "puuid": "puuid-Ninja-5605",
+      "gameName": "Ninja",
       "tagLine": "NA1",
-      "teamId": "Red",
-      "partyId": "party-1",
-      "characterId": "Reyna",
+      "teamId": "Blue",
+      "partyId": "party-2",
+      "characterId": "Phoenix",
       "stats": {
-        "kills": 20,
-        "deaths": 21,
-        "assists": 11,
-        "score": 3580,
-        "playtimeMillis": 2157849,
+        "kills": 15,
+        "deaths": 12,
+        "assists": 3,
+        "score": 2598,
+        "playtimeMillis": 2274354,
         "damage": [
           {
-            "damage": 4536
+            "damage": 5497
           }
         ],
         "economy": {
-          "spent": 88389,
-          "loadoutValue": 3731
+          "spent": 76836,
+          "loadoutValue": 3992
         }
       },
-      "competitiveTier": 16
+      "competitiveTier": 20
     },
     {
-      "puuid": "puuid-player-9-2943",
-      "gameName": "Sacy",
-      "tagLine": "BR1",
+      "puuid": "puuid-ScreaM-4935",
+      "gameName": "ScreaM",
+      "tagLine": "LAS",
       "teamId": "Red",
       "partyId": "party-1",
       "characterId": "Killjoy",
       "stats": {
-        "kills": 14,
-        "deaths": 20,
-        "assists": 5,
-        "score": 2277,
-        "playtimeMillis": 2102321,
+        "kills": 27,
+        "deaths": 18,
+        "assists": 15,
+        "score": 4907,
+        "playtimeMillis": 1904991,
         "damage": [
           {
-            "damage": 4730
+            "damage": 4278
           }
         ],
         "economy": {
-          "spent": 71013,
-          "loadoutValue": 3017
+          "spent": 81667,
+          "loadoutValue": 4846
         }
       },
-      "competitiveTier": 21
+      "competitiveTier": 25
+    },
+    {
+      "puuid": "puuid-PlayerOne-6760",
+      "gameName": "PlayerOne",
+      "tagLine": "LAS",
+      "teamId": "Red",
+      "partyId": "party-5",
+      "characterId": "Brimstone",
+      "stats": {
+        "kills": 28,
+        "deaths": 16,
+        "assists": 9,
+        "score": 5033,
+        "playtimeMillis": 2169533,
+        "damage": [
+          {
+            "damage": 4980
+          }
+        ],
+        "economy": {
+          "spent": 99325,
+          "loadoutValue": 3428
+        }
+      },
+      "competitiveTier": 22
+    },
+    {
+      "puuid": "puuid-Steel-6866",
+      "gameName": "Steel",
+      "tagLine": "NA1",
+      "teamId": "Red",
+      "partyId": "party-4",
+      "characterId": "Reyna",
+      "stats": {
+        "kills": 21,
+        "deaths": 15,
+        "assists": 10,
+        "score": 3196,
+        "playtimeMillis": 1950158,
+        "damage": [
+          {
+            "damage": 2784
+          }
+        ],
+        "economy": {
+          "spent": 97005,
+          "loadoutValue": 3122
+        }
+      },
+      "competitiveTier": 19
+    },
+    {
+      "puuid": "puuid-Sacy-8831",
+      "gameName": "Sacy",
+      "tagLine": "BR1",
+      "teamId": "Red",
+      "partyId": "party-1",
+      "characterId": "Sage",
+      "stats": {
+        "kills": 28,
+        "deaths": 18,
+        "assists": 4,
+        "score": 4875,
+        "playtimeMillis": 2046832,
+        "damage": [
+          {
+            "damage": 3720
+          }
+        ],
+        "economy": {
+          "spent": 82276,
+          "loadoutValue": 4234
+        }
+      },
+      "competitiveTier": 15
+    },
+    {
+      "puuid": "puuid-Tenz-6712",
+      "gameName": "Tenz",
+      "tagLine": "NA1",
+      "teamId": "Red",
+      "partyId": "party-5",
+      "characterId": "Omen",
+      "stats": {
+        "kills": 18,
+        "deaths": 19,
+        "assists": 9,
+        "score": 3619,
+        "playtimeMillis": 2044111,
+        "damage": [
+          {
+            "damage": 5346
+          }
+        ],
+        "economy": {
+          "spent": 71953,
+          "loadoutValue": 3407
+        }
+      },
+      "competitiveTier": 16
     }
   ],
   "teams": [
     {
       "teamId": "Blue",
-      "won": false,
-      "roundsWon": 11,
-      "roundsPlayed": 24
+      "won": true,
+      "roundsWon": 13,
+      "roundsPlayed": 25
     },
     {
       "teamId": "Red",
-      "won": true,
-      "roundsWon": 13,
-      "roundsPlayed": 24
+      "won": false,
+      "roundsWon": 12,
+      "roundsPlayed": 25
     }
   ],
   "roundResults": [
@@ -289,7 +289,7 @@
     },
     {
       "roundNum": 4,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 5,
@@ -297,11 +297,11 @@
     },
     {
       "roundNum": 6,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 7,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 8,
@@ -309,19 +309,19 @@
     },
     {
       "roundNum": 9,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 10,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 11,
       "winningTeam": "Blue"
     },
     {
-      "roundNum": 12,
+      "roundNum": 10,
+      "winningTeam": "Blue"
+    },
+    {
+      "roundNum": 11,
       "winningTeam": "Red"
+    },
+    {
+      "roundNum": 12,
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 13,
@@ -329,19 +329,19 @@
     },
     {
       "roundNum": 14,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 15,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 16,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 17,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 18,
@@ -349,19 +349,19 @@
     },
     {
       "roundNum": 19,
-      "winningTeam": "Blue"
-    },
-    {
-      "roundNum": 20,
       "winningTeam": "Red"
     },
     {
-      "roundNum": 21,
+      "roundNum": 20,
       "winningTeam": "Blue"
     },
     {
+      "roundNum": 21,
+      "winningTeam": "Red"
+    },
+    {
       "roundNum": 22,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 23,
@@ -370,6 +370,10 @@
     {
       "roundNum": 24,
       "winningTeam": "Red"
+    },
+    {
+      "roundNum": 25,
+      "winningTeam": "Blue"
     }
   ]
 }

--- a/server/mocks/match-3.json
+++ b/server/mocks/match-3.json
@@ -1,8 +1,8 @@
 {
   "matchInfo": {
     "matchId": "match-3",
-    "mapId": "/Game/Maps/Ascent/Ascent",
-    "gameLengthMillis": 2165487,
+    "mapId": "/Game/Maps/Haven/Haven",
+    "gameLengthMillis": 2032612,
     "gameStartMillis": 1725154800000,
     "provisioningFlowId": "Competitive",
     "isCompleted": true,
@@ -10,268 +10,268 @@
   },
   "players": [
     {
-      "puuid": "puuid-player-0-5630",
-      "gameName": "PlayerOne",
-      "tagLine": "EUW",
+      "puuid": "puuid-Shroud-6511",
+      "gameName": "Shroud",
+      "tagLine": "BR1",
       "teamId": "Blue",
-      "partyId": "party-4",
+      "partyId": "party-2",
       "characterId": "Jett",
       "stats": {
-        "kills": 24,
-        "deaths": 11,
-        "assists": 14,
-        "score": 4456,
-        "playtimeMillis": 2050058,
+        "kills": 22,
+        "deaths": 16,
+        "assists": 3,
+        "score": 3016,
+        "playtimeMillis": 2395878,
         "damage": [
           {
-            "damage": 3841
+            "damage": 2760
           }
         ],
         "economy": {
-          "spent": 89276,
-          "loadoutValue": 4983
+          "spent": 83019,
+          "loadoutValue": 4176
         }
       },
-      "competitiveTier": 17
+      "competitiveTier": 15
     },
     {
-      "puuid": "puuid-player-1-6123",
-      "gameName": "Ninja",
-      "tagLine": "NA1",
+      "puuid": "puuid-ScreaM-7083",
+      "gameName": "ScreaM",
+      "tagLine": "EUW",
       "teamId": "Blue",
-      "partyId": "party-3",
-      "characterId": "Phoenix",
+      "partyId": "party-2",
+      "characterId": "Killjoy",
       "stats": {
-        "kills": 19,
-        "deaths": 13,
-        "assists": 15,
-        "score": 3619,
-        "playtimeMillis": 2004131,
+        "kills": 27,
+        "deaths": 10,
+        "assists": 5,
+        "score": 4423,
+        "playtimeMillis": 2241099,
         "damage": [
           {
-            "damage": 4900
+            "damage": 5544
           }
         ],
         "economy": {
-          "spent": 67096,
-          "loadoutValue": 3005
+          "spent": 72950,
+          "loadoutValue": 4280
         }
       },
       "competitiveTier": 17
     },
     {
-      "puuid": "puuid-player-2-9218",
-      "gameName": "Shroud",
-      "tagLine": "KR1",
+      "puuid": "puuid-Ace-1465",
+      "gameName": "Ace",
+      "tagLine": "EUW",
       "teamId": "Blue",
       "partyId": "party-5",
-      "characterId": "Sage",
+      "characterId": "Reyna",
       "stats": {
-        "kills": 21,
-        "deaths": 10,
-        "assists": 9,
-        "score": 3554,
-        "playtimeMillis": 2040092,
+        "kills": 13,
+        "deaths": 12,
+        "assists": 12,
+        "score": 2935,
+        "playtimeMillis": 2282025,
         "damage": [
           {
-            "damage": 4598
+            "damage": 3348
           }
         ],
         "economy": {
-          "spent": 90601,
-          "loadoutValue": 3427
+          "spent": 71910,
+          "loadoutValue": 3426
         }
       },
       "competitiveTier": 19
     },
     {
-      "puuid": "puuid-player-3-9860",
-      "gameName": "Tenz",
+      "puuid": "puuid-Sacy-6900",
+      "gameName": "Sacy",
       "tagLine": "BR1",
       "teamId": "Blue",
-      "partyId": "party-1",
-      "characterId": "Sova",
+      "partyId": "party-2",
+      "characterId": "Phoenix",
       "stats": {
-        "kills": 22,
-        "deaths": 11,
-        "assists": 2,
-        "score": 3524,
-        "playtimeMillis": 2127030,
+        "kills": 23,
+        "deaths": 16,
+        "assists": 9,
+        "score": 4118,
+        "playtimeMillis": 2194289,
         "damage": [
           {
-            "damage": 4000
+            "damage": 4642
           }
         ],
         "economy": {
-          "spent": 65848,
-          "loadoutValue": 4593
+          "spent": 96796,
+          "loadoutValue": 4919
         }
       },
       "competitiveTier": 24
     },
     {
-      "puuid": "puuid-player-4-3420",
-      "gameName": "ScreaM",
-      "tagLine": "LAS",
+      "puuid": "puuid-Tenz-1202",
+      "gameName": "Tenz",
+      "tagLine": "KR1",
       "teamId": "Blue",
       "partyId": "party-4",
       "characterId": "Brimstone",
       "stats": {
-        "kills": 27,
-        "deaths": 15,
-        "assists": 14,
-        "score": 4839,
-        "playtimeMillis": 2113375,
+        "kills": 8,
+        "deaths": 10,
+        "assists": 11,
+        "score": 1422,
+        "playtimeMillis": 2099519,
         "damage": [
           {
-            "damage": 3358
+            "damage": 3276
           }
         ],
         "economy": {
-          "spent": 69339,
-          "loadoutValue": 3195
+          "spent": 98257,
+          "loadoutValue": 4210
         }
       },
-      "competitiveTier": 20
+      "competitiveTier": 21
     },
     {
-      "puuid": "puuid-player-5-8132",
-      "gameName": "Mixwell",
-      "tagLine": "NA1",
-      "teamId": "Red",
-      "partyId": "party-5",
-      "characterId": "Viper",
-      "stats": {
-        "kills": 6,
-        "deaths": 15,
-        "assists": 6,
-        "score": 1267,
-        "playtimeMillis": 2105228,
-        "damage": [
-          {
-            "damage": 2812
-          }
-        ],
-        "economy": {
-          "spent": 73611,
-          "loadoutValue": 3360
-        }
-      },
-      "competitiveTier": 17
-    },
-    {
-      "puuid": "puuid-player-6-8569",
+      "puuid": "puuid-Hiko-8454",
       "gameName": "Hiko",
       "tagLine": "NA1",
-      "teamId": "Red",
-      "partyId": "party-5",
-      "characterId": "Omen",
-      "stats": {
-        "kills": 15,
-        "deaths": 18,
-        "assists": 4,
-        "score": 2751,
-        "playtimeMillis": 2075228,
-        "damage": [
-          {
-            "damage": 5229
-          }
-        ],
-        "economy": {
-          "spent": 69107,
-          "loadoutValue": 4358
-        }
-      },
-      "competitiveTier": 16
-    },
-    {
-      "puuid": "puuid-player-7-4968",
-      "gameName": "Steel",
-      "tagLine": "LAS",
       "teamId": "Red",
       "partyId": "party-3",
       "characterId": "Cypher",
       "stats": {
-        "kills": 28,
-        "deaths": 13,
-        "assists": 3,
-        "score": 3868,
-        "playtimeMillis": 2025364,
+        "kills": 11,
+        "deaths": 20,
+        "assists": 2,
+        "score": 2200,
+        "playtimeMillis": 2063344,
         "damage": [
           {
-            "damage": 2457
+            "damage": 3840
           }
         ],
         "economy": {
-          "spent": 86722,
-          "loadoutValue": 3319
+          "spent": 71293,
+          "loadoutValue": 4505
         }
       },
       "competitiveTier": 23
     },
     {
-      "puuid": "puuid-player-8-2465",
-      "gameName": "Ace",
-      "tagLine": "LAS",
-      "teamId": "Red",
-      "partyId": "party-1",
-      "characterId": "Reyna",
-      "stats": {
-        "kills": 26,
-        "deaths": 22,
-        "assists": 15,
-        "score": 4410,
-        "playtimeMillis": 2012296,
-        "damage": [
-          {
-            "damage": 2337
-          }
-        ],
-        "economy": {
-          "spent": 98812,
-          "loadoutValue": 3895
-        }
-      },
-      "competitiveTier": 16
-    },
-    {
-      "puuid": "puuid-player-9-1567",
-      "gameName": "Sacy",
-      "tagLine": "KR1",
+      "puuid": "puuid-PlayerOne-2278",
+      "gameName": "PlayerOne",
+      "tagLine": "EUW",
       "teamId": "Red",
       "partyId": "party-5",
-      "characterId": "Killjoy",
+      "characterId": "Viper",
       "stats": {
-        "kills": 29,
-        "deaths": 16,
-        "assists": 7,
-        "score": 4964,
-        "playtimeMillis": 2080271,
+        "kills": 24,
+        "deaths": 11,
+        "assists": 12,
+        "score": 4490,
+        "playtimeMillis": 1887846,
         "damage": [
           {
-            "damage": 3129
+            "damage": 3458
           }
         ],
         "economy": {
-          "spent": 99623,
-          "loadoutValue": 3516
+          "spent": 98005,
+          "loadoutValue": 3884
         }
       },
-      "competitiveTier": 16
+      "competitiveTier": 18
+    },
+    {
+      "puuid": "puuid-Steel-5471",
+      "gameName": "Steel",
+      "tagLine": "NA1",
+      "teamId": "Red",
+      "partyId": "party-1",
+      "characterId": "Omen",
+      "stats": {
+        "kills": 8,
+        "deaths": 12,
+        "assists": 9,
+        "score": 1647,
+        "playtimeMillis": 2004176,
+        "damage": [
+          {
+            "damage": 2816
+          }
+        ],
+        "economy": {
+          "spent": 94075,
+          "loadoutValue": 3975
+        }
+      },
+      "competitiveTier": 17
+    },
+    {
+      "puuid": "puuid-Mixwell-3376",
+      "gameName": "Mixwell",
+      "tagLine": "EUW",
+      "teamId": "Red",
+      "partyId": "party-2",
+      "characterId": "Sova",
+      "stats": {
+        "kills": 14,
+        "deaths": 14,
+        "assists": 14,
+        "score": 2987,
+        "playtimeMillis": 2297031,
+        "damage": [
+          {
+            "damage": 5592
+          }
+        ],
+        "economy": {
+          "spent": 80841,
+          "loadoutValue": 4516
+        }
+      },
+      "competitiveTier": 21
+    },
+    {
+      "puuid": "puuid-Ninja-1472",
+      "gameName": "Ninja",
+      "tagLine": "EUW",
+      "teamId": "Red",
+      "partyId": "party-2",
+      "characterId": "Sage",
+      "stats": {
+        "kills": 9,
+        "deaths": 18,
+        "assists": 6,
+        "score": 1964,
+        "playtimeMillis": 2039477,
+        "damage": [
+          {
+            "damage": 3211
+          }
+        ],
+        "economy": {
+          "spent": 71689,
+          "loadoutValue": 3239
+        }
+      },
+      "competitiveTier": 23
     }
   ],
   "teams": [
     {
       "teamId": "Blue",
-      "won": true,
-      "roundsWon": 13,
-      "roundsPlayed": 23
+      "won": false,
+      "roundsWon": 9,
+      "roundsPlayed": 22
     },
     {
       "teamId": "Red",
-      "won": false,
-      "roundsWon": 10,
-      "roundsPlayed": 23
+      "won": true,
+      "roundsWon": 13,
+      "roundsPlayed": 22
     }
   ],
   "roundResults": [
@@ -285,7 +285,7 @@
     },
     {
       "roundNum": 3,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 4,
@@ -309,7 +309,7 @@
     },
     {
       "roundNum": 9,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 10,
@@ -329,7 +329,7 @@
     },
     {
       "roundNum": 14,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 15,
@@ -349,7 +349,7 @@
     },
     {
       "roundNum": 19,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 20,
@@ -357,15 +357,11 @@
     },
     {
       "roundNum": 21,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 22,
       "winningTeam": "Red"
-    },
-    {
-      "roundNum": 23,
-      "winningTeam": "Blue"
     }
   ]
 }

--- a/server/mocks/match-4.json
+++ b/server/mocks/match-4.json
@@ -1,8 +1,8 @@
 {
   "matchInfo": {
     "matchId": "match-4",
-    "mapId": "/Game/Maps/Ascent/Ascent",
-    "gameLengthMillis": 2165487,
+    "mapId": "/Game/Maps/Split/Split",
+    "gameLengthMillis": 2394849,
     "gameStartMillis": 1725154800000,
     "provisioningFlowId": "Competitive",
     "isCompleted": true,
@@ -10,254 +10,254 @@
   },
   "players": [
     {
-      "puuid": "puuid-player-0-2708",
+      "puuid": "puuid-Ninja-9790",
+      "gameName": "Ninja",
+      "tagLine": "EUW",
+      "teamId": "Blue",
+      "partyId": "party-4",
+      "characterId": "Omen",
+      "stats": {
+        "kills": 24,
+        "deaths": 19,
+        "assists": 14,
+        "score": 3968,
+        "playtimeMillis": 1803436,
+        "damage": [
+          {
+            "damage": 3096
+          }
+        ],
+        "economy": {
+          "spent": 78857,
+          "loadoutValue": 4891
+        }
+      },
+      "competitiveTier": 17
+    },
+    {
+      "puuid": "puuid-PlayerOne-5412",
       "gameName": "PlayerOne",
       "tagLine": "LAS",
+      "teamId": "Blue",
+      "partyId": "party-1",
+      "characterId": "Killjoy",
+      "stats": {
+        "kills": 23,
+        "deaths": 14,
+        "assists": 15,
+        "score": 4545,
+        "playtimeMillis": 1947002,
+        "damage": [
+          {
+            "damage": 5061
+          }
+        ],
+        "economy": {
+          "spent": 64128,
+          "loadoutValue": 3285
+        }
+      },
+      "competitiveTier": 15
+    },
+    {
+      "puuid": "puuid-Tenz-5947",
+      "gameName": "Tenz",
+      "tagLine": "LAS",
+      "teamId": "Blue",
+      "partyId": "party-3",
+      "characterId": "Cypher",
+      "stats": {
+        "kills": 11,
+        "deaths": 15,
+        "assists": 4,
+        "score": 1525,
+        "playtimeMillis": 2306491,
+        "damage": [
+          {
+            "damage": 2736
+          }
+        ],
+        "economy": {
+          "spent": 90849,
+          "loadoutValue": 3990
+        }
+      },
+      "competitiveTier": 22
+    },
+    {
+      "puuid": "puuid-Shroud-1798",
+      "gameName": "Shroud",
+      "tagLine": "KR1",
       "teamId": "Blue",
       "partyId": "party-5",
       "characterId": "Jett",
       "stats": {
-        "kills": 16,
-        "deaths": 11,
-        "assists": 12,
-        "score": 3362,
-        "playtimeMillis": 2032127,
-        "damage": [
-          {
-            "damage": 4332
-          }
-        ],
-        "economy": {
-          "spent": 62460,
-          "loadoutValue": 3305
-        }
-      },
-      "competitiveTier": 20
-    },
-    {
-      "puuid": "puuid-player-1-7931",
-      "gameName": "Ninja",
-      "tagLine": "NA1",
-      "teamId": "Blue",
-      "partyId": "party-1",
-      "characterId": "Phoenix",
-      "stats": {
-        "kills": 29,
-        "deaths": 12,
-        "assists": 12,
-        "score": 4533,
-        "playtimeMillis": 2041300,
-        "damage": [
-          {
-            "damage": 3864
-          }
-        ],
-        "economy": {
-          "spent": 80885,
-          "loadoutValue": 3784
-        }
-      },
-      "competitiveTier": 25
-    },
-    {
-      "puuid": "puuid-player-2-2700",
-      "gameName": "Shroud",
-      "tagLine": "BR1",
-      "teamId": "Blue",
-      "partyId": "party-4",
-      "characterId": "Sage",
-      "stats": {
-        "kills": 20,
-        "deaths": 21,
+        "kills": 28,
+        "deaths": 19,
         "assists": 7,
-        "score": 3431,
-        "playtimeMillis": 2096682,
+        "score": 4281,
+        "playtimeMillis": 2218565,
         "damage": [
           {
-            "damage": 3980
+            "damage": 2442
           }
         ],
         "economy": {
-          "spent": 62342,
-          "loadoutValue": 3528
-        }
-      },
-      "competitiveTier": 18
-    },
-    {
-      "puuid": "puuid-player-3-5313",
-      "gameName": "Tenz",
-      "tagLine": "EUW",
-      "teamId": "Blue",
-      "partyId": "party-4",
-      "characterId": "Sova",
-      "stats": {
-        "kills": 13,
-        "deaths": 11,
-        "assists": 2,
-        "score": 1734,
-        "playtimeMillis": 2152464,
-        "damage": [
-          {
-            "damage": 3625
-          }
-        ],
-        "economy": {
-          "spent": 74394,
-          "loadoutValue": 4192
-        }
-      },
-      "competitiveTier": 21
-    },
-    {
-      "puuid": "puuid-player-4-3969",
-      "gameName": "ScreaM",
-      "tagLine": "NA1",
-      "teamId": "Blue",
-      "partyId": "party-2",
-      "characterId": "Brimstone",
-      "stats": {
-        "kills": 18,
-        "deaths": 20,
-        "assists": 14,
-        "score": 3248,
-        "playtimeMillis": 2144261,
-        "damage": [
-          {
-            "damage": 4510
-          }
-        ],
-        "economy": {
-          "spent": 73026,
-          "loadoutValue": 3038
+          "spent": 64849,
+          "loadoutValue": 3453
         }
       },
       "competitiveTier": 23
     },
     {
-      "puuid": "puuid-player-5-6330",
-      "gameName": "Mixwell",
-      "tagLine": "EUW",
-      "teamId": "Red",
-      "partyId": "party-3",
-      "characterId": "Viper",
+      "puuid": "puuid-Hiko-1600",
+      "gameName": "Hiko",
+      "tagLine": "KR1",
+      "teamId": "Blue",
+      "partyId": "party-4",
+      "characterId": "Brimstone",
       "stats": {
-        "kills": 25,
-        "deaths": 12,
-        "assists": 11,
-        "score": 3865,
-        "playtimeMillis": 2137424,
+        "kills": 15,
+        "deaths": 17,
+        "assists": 4,
+        "score": 2629,
+        "playtimeMillis": 2397138,
         "damage": [
           {
-            "damage": 3465
+            "damage": 3640
           }
         ],
         "economy": {
-          "spent": 86211,
-          "loadoutValue": 4385
+          "spent": 99678,
+          "loadoutValue": 4987
         }
       },
       "competitiveTier": 18
     },
     {
-      "puuid": "puuid-player-6-9852",
-      "gameName": "Hiko",
-      "tagLine": "LAS",
-      "teamId": "Red",
-      "partyId": "party-5",
-      "characterId": "Omen",
-      "stats": {
-        "kills": 23,
-        "deaths": 16,
-        "assists": 11,
-        "score": 4009,
-        "playtimeMillis": 2092980,
-        "damage": [
-          {
-            "damage": 4200
-          }
-        ],
-        "economy": {
-          "spent": 81286,
-          "loadoutValue": 3216
-        }
-      },
-      "competitiveTier": 22
-    },
-    {
-      "puuid": "puuid-player-7-4664",
-      "gameName": "Steel",
-      "tagLine": "LAS",
-      "teamId": "Red",
-      "partyId": "party-2",
-      "characterId": "Cypher",
-      "stats": {
-        "kills": 11,
-        "deaths": 22,
-        "assists": 17,
-        "score": 2387,
-        "playtimeMillis": 2091361,
-        "damage": [
-          {
-            "damage": 2898
-          }
-        ],
-        "economy": {
-          "spent": 70163,
-          "loadoutValue": 4544
-        }
-      },
-      "competitiveTier": 22
-    },
-    {
-      "puuid": "puuid-player-8-7933",
+      "puuid": "puuid-Ace-5793",
       "gameName": "Ace",
+      "tagLine": "BR1",
+      "teamId": "Red",
+      "partyId": "party-4",
+      "characterId": "Viper",
+      "stats": {
+        "kills": 14,
+        "deaths": 14,
+        "assists": 14,
+        "score": 3007,
+        "playtimeMillis": 2110884,
+        "damage": [
+          {
+            "damage": 3630
+          }
+        ],
+        "economy": {
+          "spent": 86904,
+          "loadoutValue": 3038
+        }
+      },
+      "competitiveTier": 15
+    },
+    {
+      "puuid": "puuid-Sacy-6224",
+      "gameName": "Sacy",
       "tagLine": "KR1",
       "teamId": "Red",
-      "partyId": "party-5",
-      "characterId": "Reyna",
+      "partyId": "party-1",
+      "characterId": "Sage",
       "stats": {
-        "kills": 7,
-        "deaths": 17,
+        "kills": 10,
+        "deaths": 10,
         "assists": 10,
-        "score": 1157,
-        "playtimeMillis": 2052985,
+        "score": 1803,
+        "playtimeMillis": 2025286,
         "damage": [
           {
-            "damage": 5405
+            "damage": 2646
           }
         ],
         "economy": {
-          "spent": 74965,
-          "loadoutValue": 3286
-        }
-      },
-      "competitiveTier": 16
-    },
-    {
-      "puuid": "puuid-player-9-4510",
-      "gameName": "Sacy",
-      "tagLine": "LAS",
-      "teamId": "Red",
-      "partyId": "party-3",
-      "characterId": "Killjoy",
-      "stats": {
-        "kills": 11,
-        "deaths": 19,
-        "assists": 7,
-        "score": 1878,
-        "playtimeMillis": 2021606,
-        "damage": [
-          {
-            "damage": 2280
-          }
-        ],
-        "economy": {
-          "spent": 78624,
-          "loadoutValue": 3558
+          "spent": 64014,
+          "loadoutValue": 3798
         }
       },
       "competitiveTier": 25
+    },
+    {
+      "puuid": "puuid-Steel-8998",
+      "gameName": "Steel",
+      "tagLine": "KR1",
+      "teamId": "Red",
+      "partyId": "party-3",
+      "characterId": "Phoenix",
+      "stats": {
+        "kills": 19,
+        "deaths": 14,
+        "assists": 15,
+        "score": 3399,
+        "playtimeMillis": 2364573,
+        "damage": [
+          {
+            "damage": 3096
+          }
+        ],
+        "economy": {
+          "spent": 80737,
+          "loadoutValue": 4462
+        }
+      },
+      "competitiveTier": 22
+    },
+    {
+      "puuid": "puuid-ScreaM-5523",
+      "gameName": "ScreaM",
+      "tagLine": "NA1",
+      "teamId": "Red",
+      "partyId": "party-3",
+      "characterId": "Sova",
+      "stats": {
+        "kills": 13,
+        "deaths": 12,
+        "assists": 5,
+        "score": 2444,
+        "playtimeMillis": 2123636,
+        "damage": [
+          {
+            "damage": 4351
+          }
+        ],
+        "economy": {
+          "spent": 65807,
+          "loadoutValue": 4540
+        }
+      },
+      "competitiveTier": 20
+    },
+    {
+      "puuid": "puuid-Mixwell-5361",
+      "gameName": "Mixwell",
+      "tagLine": "EUW",
+      "teamId": "Red",
+      "partyId": "party-3",
+      "characterId": "Reyna",
+      "stats": {
+        "kills": 16,
+        "deaths": 10,
+        "assists": 3,
+        "score": 2463,
+        "playtimeMillis": 2059044,
+        "damage": [
+          {
+            "damage": 2160
+          }
+        ],
+        "economy": {
+          "spent": 85606,
+          "loadoutValue": 3077
+        }
+      },
+      "competitiveTier": 19
     }
   ],
   "teams": [
@@ -265,19 +265,19 @@
       "teamId": "Blue",
       "won": true,
       "roundsWon": 13,
-      "roundsPlayed": 20
+      "roundsPlayed": 19
     },
     {
       "teamId": "Red",
       "won": false,
-      "roundsWon": 7,
-      "roundsPlayed": 20
+      "roundsWon": 6,
+      "roundsPlayed": 19
     }
   ],
   "roundResults": [
     {
       "roundNum": 1,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 2,
@@ -289,7 +289,7 @@
     },
     {
       "roundNum": 4,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 5,
@@ -297,7 +297,7 @@
     },
     {
       "roundNum": 6,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 7,
@@ -313,23 +313,23 @@
     },
     {
       "roundNum": 10,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 11,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 12,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 13,
       "winningTeam": "Blue"
     },
     {
-      "roundNum": 14,
+      "roundNum": 12,
+      "winningTeam": "Blue"
+    },
+    {
+      "roundNum": 13,
       "winningTeam": "Red"
+    },
+    {
+      "roundNum": 14,
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 15,
@@ -337,22 +337,18 @@
     },
     {
       "roundNum": 16,
-      "winningTeam": "Blue"
-    },
-    {
-      "roundNum": 17,
-      "winningTeam": "Blue"
-    },
-    {
-      "roundNum": 18,
       "winningTeam": "Red"
     },
     {
-      "roundNum": 19,
+      "roundNum": 17,
+      "winningTeam": "Red"
+    },
+    {
+      "roundNum": 18,
       "winningTeam": "Blue"
     },
     {
-      "roundNum": 20,
+      "roundNum": 19,
       "winningTeam": "Blue"
     }
   ]

--- a/server/mocks/match-5.json
+++ b/server/mocks/match-5.json
@@ -1,8 +1,8 @@
 {
   "matchInfo": {
     "matchId": "match-5",
-    "mapId": "/Game/Maps/Ascent/Ascent",
-    "gameLengthMillis": 2165487,
+    "mapId": "/Game/Maps/Icebox/Icebox",
+    "gameLengthMillis": 1840609,
     "gameStartMillis": 1725154800000,
     "provisioningFlowId": "Competitive",
     "isCompleted": true,
@@ -10,268 +10,268 @@
   },
   "players": [
     {
-      "puuid": "puuid-player-0-8638",
-      "gameName": "PlayerOne",
-      "tagLine": "NA1",
+      "puuid": "puuid-Ace-3416",
+      "gameName": "Ace",
+      "tagLine": "EUW",
       "teamId": "Blue",
-      "partyId": "party-4",
-      "characterId": "Jett",
+      "partyId": "party-1",
+      "characterId": "Omen",
       "stats": {
-        "kills": 19,
-        "deaths": 11,
-        "assists": 12,
-        "score": 3068,
-        "playtimeMillis": 2096154,
+        "kills": 8,
+        "deaths": 13,
+        "assists": 13,
+        "score": 2067,
+        "playtimeMillis": 2359790,
         "damage": [
           {
-            "damage": 3211
+            "damage": 4884
           }
         ],
         "economy": {
-          "spent": 78056,
-          "loadoutValue": 3480
+          "spent": 74185,
+          "loadoutValue": 3809
         }
       },
-      "competitiveTier": 18
+      "competitiveTier": 22
     },
     {
-      "puuid": "puuid-player-1-7855",
-      "gameName": "Ninja",
+      "puuid": "puuid-Tenz-4499",
+      "gameName": "Tenz",
       "tagLine": "NA1",
       "teamId": "Blue",
       "partyId": "party-5",
-      "characterId": "Phoenix",
+      "characterId": "Jett",
       "stats": {
-        "kills": 27,
-        "deaths": 11,
-        "assists": 8,
-        "score": 4257,
-        "playtimeMillis": 2005588,
-        "damage": [
-          {
-            "damage": 2346
-          }
-        ],
-        "economy": {
-          "spent": 76166,
-          "loadoutValue": 5000
-        }
-      },
-      "competitiveTier": 18
-    },
-    {
-      "puuid": "puuid-player-2-4747",
-      "gameName": "Shroud",
-      "tagLine": "BR1",
-      "teamId": "Blue",
-      "partyId": "party-3",
-      "characterId": "Sage",
-      "stats": {
-        "kills": 20,
-        "deaths": 10,
-        "assists": 15,
-        "score": 3674,
-        "playtimeMillis": 2055749,
-        "damage": [
-          {
-            "damage": 3249
-          }
-        ],
-        "economy": {
-          "spent": 94602,
-          "loadoutValue": 3110
-        }
-      },
-      "competitiveTier": 24
-    },
-    {
-      "puuid": "puuid-player-3-9926",
-      "gameName": "Tenz",
-      "tagLine": "LAS",
-      "teamId": "Blue",
-      "partyId": "party-4",
-      "characterId": "Sova",
-      "stats": {
-        "kills": 7,
-        "deaths": 15,
-        "assists": 8,
-        "score": 1390,
-        "playtimeMillis": 2000192,
-        "damage": [
-          {
-            "damage": 2934
-          }
-        ],
-        "economy": {
-          "spent": 71481,
-          "loadoutValue": 3027
-        }
-      },
-      "competitiveTier": 19
-    },
-    {
-      "puuid": "puuid-player-4-3268",
-      "gameName": "ScreaM",
-      "tagLine": "KR1",
-      "teamId": "Blue",
-      "partyId": "party-4",
-      "characterId": "Brimstone",
-      "stats": {
-        "kills": 24,
-        "deaths": 12,
-        "assists": 12,
-        "score": 4682,
-        "playtimeMillis": 2036155,
-        "damage": [
-          {
-            "damage": 3743
-          }
-        ],
-        "economy": {
-          "spent": 62373,
-          "loadoutValue": 4769
-        }
-      },
-      "competitiveTier": 21
-    },
-    {
-      "puuid": "puuid-player-5-8576",
-      "gameName": "Mixwell",
-      "tagLine": "NA1",
-      "teamId": "Red",
-      "partyId": "party-3",
-      "characterId": "Viper",
-      "stats": {
-        "kills": 24,
+        "kills": 16,
         "deaths": 18,
-        "assists": 17,
-        "score": 4212,
-        "playtimeMillis": 2162925,
+        "assists": 6,
+        "score": 2946,
+        "playtimeMillis": 1941618,
         "damage": [
           {
-            "damage": 3772
+            "damage": 5106
           }
         ],
         "economy": {
-          "spent": 99838,
-          "loadoutValue": 4624
+          "spent": 75553,
+          "loadoutValue": 3031
         }
       },
-      "competitiveTier": 23
+      "competitiveTier": 17
     },
     {
-      "puuid": "puuid-player-6-3594",
-      "gameName": "Hiko",
+      "puuid": "puuid-Steel-9365",
+      "gameName": "Steel",
       "tagLine": "NA1",
-      "teamId": "Red",
-      "partyId": "party-4",
-      "characterId": "Omen",
+      "teamId": "Blue",
+      "partyId": "party-3",
+      "characterId": "Reyna",
       "stats": {
-        "kills": 20,
-        "deaths": 13,
-        "assists": 3,
-        "score": 3439,
-        "playtimeMillis": 2053828,
+        "kills": 13,
+        "deaths": 14,
+        "assists": 5,
+        "score": 1971,
+        "playtimeMillis": 1991377,
         "damage": [
           {
-            "damage": 4389
+            "damage": 3336
           }
         ],
         "economy": {
-          "spent": 83948,
-          "loadoutValue": 4946
+          "spent": 78057,
+          "loadoutValue": 3338
         }
       },
       "competitiveTier": 25
     },
     {
-      "puuid": "puuid-player-7-3928",
-      "gameName": "Steel",
-      "tagLine": "EUW",
-      "teamId": "Red",
-      "partyId": "party-1",
-      "characterId": "Cypher",
+      "puuid": "puuid-Sacy-2612",
+      "gameName": "Sacy",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "partyId": "party-2",
+      "characterId": "Phoenix",
       "stats": {
-        "kills": 10,
-        "deaths": 13,
-        "assists": 2,
-        "score": 1945,
-        "playtimeMillis": 2055322,
+        "kills": 15,
+        "deaths": 12,
+        "assists": 15,
+        "score": 3103,
+        "playtimeMillis": 2289048,
         "damage": [
           {
-            "damage": 3255
+            "damage": 2680
           }
         ],
         "economy": {
-          "spent": 87164,
-          "loadoutValue": 4725
+          "spent": 76845,
+          "loadoutValue": 3081
         }
       },
       "competitiveTier": 16
     },
     {
-      "puuid": "puuid-player-8-2343",
-      "gameName": "Ace",
-      "tagLine": "NA1",
-      "teamId": "Red",
-      "partyId": "party-4",
-      "characterId": "Reyna",
+      "puuid": "puuid-ScreaM-3117",
+      "gameName": "ScreaM",
+      "tagLine": "LAS",
+      "teamId": "Blue",
+      "partyId": "party-3",
+      "characterId": "Sage",
       "stats": {
-        "kills": 29,
-        "deaths": 18,
-        "assists": 14,
-        "score": 4770,
-        "playtimeMillis": 2052182,
+        "kills": 11,
+        "deaths": 11,
+        "assists": 10,
+        "score": 2417,
+        "playtimeMillis": 2209792,
         "damage": [
           {
-            "damage": 5975
+            "damage": 1995
           }
         ],
         "economy": {
-          "spent": 72905,
-          "loadoutValue": 3233
+          "spent": 64094,
+          "loadoutValue": 3608
         }
       },
-      "competitiveTier": 15
+      "competitiveTier": 17
     },
     {
-      "puuid": "puuid-player-9-4347",
-      "gameName": "Sacy",
+      "puuid": "puuid-Mixwell-1188",
+      "gameName": "Mixwell",
+      "tagLine": "EUW",
+      "teamId": "Red",
+      "partyId": "party-2",
+      "characterId": "Viper",
+      "stats": {
+        "kills": 18,
+        "deaths": 17,
+        "assists": 2,
+        "score": 2701,
+        "playtimeMillis": 2295345,
+        "damage": [
+          {
+            "damage": 3857
+          }
+        ],
+        "economy": {
+          "spent": 68248,
+          "loadoutValue": 5000
+        }
+      },
+      "competitiveTier": 24
+    },
+    {
+      "puuid": "puuid-Shroud-6305",
+      "gameName": "Shroud",
       "tagLine": "KR1",
+      "teamId": "Red",
+      "partyId": "party-1",
+      "characterId": "Cypher",
+      "stats": {
+        "kills": 8,
+        "deaths": 11,
+        "assists": 5,
+        "score": 1537,
+        "playtimeMillis": 2015850,
+        "damage": [
+          {
+            "damage": 3528
+          }
+        ],
+        "economy": {
+          "spent": 83928,
+          "loadoutValue": 4346
+        }
+      },
+      "competitiveTier": 21
+    },
+    {
+      "puuid": "puuid-Hiko-2113",
+      "gameName": "Hiko",
+      "tagLine": "BR1",
+      "teamId": "Red",
+      "partyId": "party-3",
+      "characterId": "Sova",
+      "stats": {
+        "kills": 27,
+        "deaths": 11,
+        "assists": 15,
+        "score": 5036,
+        "playtimeMillis": 2171552,
+        "damage": [
+          {
+            "damage": 2356
+          }
+        ],
+        "economy": {
+          "spent": 99738,
+          "loadoutValue": 4089
+        }
+      },
+      "competitiveTier": 17
+    },
+    {
+      "puuid": "puuid-Ninja-8176",
+      "gameName": "Ninja",
+      "tagLine": "NA1",
+      "teamId": "Red",
+      "partyId": "party-1",
+      "characterId": "Brimstone",
+      "stats": {
+        "kills": 15,
+        "deaths": 12,
+        "assists": 5,
+        "score": 2187,
+        "playtimeMillis": 2217118,
+        "damage": [
+          {
+            "damage": 4848
+          }
+        ],
+        "economy": {
+          "spent": 99292,
+          "loadoutValue": 4936
+        }
+      },
+      "competitiveTier": 22
+    },
+    {
+      "puuid": "puuid-PlayerOne-2285",
+      "gameName": "PlayerOne",
+      "tagLine": "EUW",
       "teamId": "Red",
       "partyId": "party-1",
       "characterId": "Killjoy",
       "stats": {
-        "kills": 10,
-        "deaths": 15,
-        "assists": 10,
-        "score": 2033,
-        "playtimeMillis": 2138281,
+        "kills": 26,
+        "deaths": 11,
+        "assists": 13,
+        "score": 4917,
+        "playtimeMillis": 2294111,
         "damage": [
           {
-            "damage": 3360
+            "damage": 3591
           }
         ],
         "economy": {
-          "spent": 67145,
-          "loadoutValue": 4871
+          "spent": 95573,
+          "loadoutValue": 3565
         }
       },
-      "competitiveTier": 21
+      "competitiveTier": 20
     }
   ],
   "teams": [
     {
       "teamId": "Blue",
-      "won": false,
-      "roundsWon": 9,
-      "roundsPlayed": 22
+      "won": true,
+      "roundsWon": 13,
+      "roundsPlayed": 16
     },
     {
       "teamId": "Red",
-      "won": true,
-      "roundsWon": 13,
-      "roundsPlayed": 22
+      "won": false,
+      "roundsWon": 3,
+      "roundsPlayed": 16
     }
   ],
   "roundResults": [
@@ -289,11 +289,11 @@
     },
     {
       "roundNum": 4,
-      "winningTeam": "Blue"
+      "winningTeam": "Red"
     },
     {
       "roundNum": 5,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 6,
@@ -301,23 +301,23 @@
     },
     {
       "roundNum": 7,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 8,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 9,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 10,
       "winningTeam": "Blue"
     },
     {
-      "roundNum": 11,
+      "roundNum": 8,
+      "winningTeam": "Blue"
+    },
+    {
+      "roundNum": 9,
+      "winningTeam": "Blue"
+    },
+    {
+      "roundNum": 10,
       "winningTeam": "Red"
+    },
+    {
+      "roundNum": 11,
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 12,
@@ -329,39 +329,15 @@
     },
     {
       "roundNum": 14,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 15,
-      "winningTeam": "Red"
+      "winningTeam": "Blue"
     },
     {
       "roundNum": 16,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 17,
       "winningTeam": "Blue"
-    },
-    {
-      "roundNum": 18,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 19,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 20,
-      "winningTeam": "Red"
-    },
-    {
-      "roundNum": 21,
-      "winningTeam": "Blue"
-    },
-    {
-      "roundNum": 22,
-      "winningTeam": "Red"
     }
   ]
 }

--- a/server/mocks/match-history.json
+++ b/server/mocks/match-history.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "match-1",
+    "map": "Ascent",
+    "result": "Derrota",
+    "score": "11 - 13",
+    "agent": "Aleatório"
+  },
+  {
+    "id": "match-2",
+    "map": "Bind",
+    "result": "Vitória",
+    "score": "13 - 12",
+    "agent": "Aleatório"
+  },
+  {
+    "id": "match-3",
+    "map": "Haven",
+    "result": "Derrota",
+    "score": "9 - 13",
+    "agent": "Aleatório"
+  },
+  {
+    "id": "match-4",
+    "map": "Split",
+    "result": "Vitória",
+    "score": "13 - 6",
+    "agent": "Aleatório"
+  },
+  {
+    "id": "match-5",
+    "map": "Icebox",
+    "result": "Vitória",
+    "score": "13 - 3",
+    "agent": "Aleatório"
+  }
+]

--- a/server/mocks/mockDataGenerator.js
+++ b/server/mocks/mockDataGenerator.js
@@ -1,86 +1,100 @@
 const fs = require('fs');
 const path = require('path');
 
-// --- Funções para gerar dados aleatórios ---
+// --- Funções Geradoras ---
 
 const getRandomInt = (min, max) => Math.floor(Math.random() * (max - min + 1)) + min;
 
+// NOVO: Função para embaralhar um array (algoritmo Fisher-Yates)
+function shuffleArray(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]]; // Troca os elementos
+  }
+}
+
 const generatePlayerStats = () => {
-  const kills = getRandomInt(5, 30);
-  const deaths = getRandomInt(10, 22);
-  const assists = getRandomInt(2, 18);
+  const kills = getRandomInt(8, 28);
+  const deaths = getRandomInt(10, 20);
+  const assists = getRandomInt(2, 15);
   const score = kills * 150 + assists * 50 + getRandomInt(-500, 500);
-  const damage = getRandomInt(100, 250) * getRandomInt(18, 25); // ADR * rounds
-  return {
-    kills,
-    deaths,
-    assists,
-    score,
-    playtimeMillis: getRandomInt(2000000, 2165000),
-    damage: [{ damage }],
-    economy: { spent: getRandomInt(60000, 100000), loadoutValue: getRandomInt(3000, 5000) }
-  };
+  const damage = getRandomInt(100, 250) * getRandomInt(18, 24);
+  return { kills, deaths, assists, score, playtimeMillis: getRandomInt(1800000, 2400000), damage: [{ damage }], economy: { spent: getRandomInt(60000, 100000), loadoutValue: getRandomInt(3000, 5000) } };
 };
 
 const AGENTS = ['Jett', 'Phoenix', 'Sage', 'Sova', 'Brimstone', 'Viper', 'Omen', 'Cypher', 'Reyna', 'Killjoy'];
 const PLAYER_NAMES = ['PlayerOne', 'Ninja', 'Shroud', 'Tenz', 'ScreaM', 'Mixwell', 'Hiko', 'Steel', 'Ace', 'Sacy'];
 const TAGS = ['BR1', 'LAS', 'NA1', 'EUW', 'KR1'];
+const MAPS = ['Ascent', 'Bind', 'Haven', 'Split', 'Icebox'];
 
-const createPlayer = (index, teamId) => ({
-  puuid: `puuid-player-${index}-${getRandomInt(1000, 9999)}`,
-  gameName: PLAYER_NAMES[index],
+// MUDANÇA: A função agora recebe o nome do jogador como parâmetro
+const createPlayer = (playerName, teamId, agent) => ({
+  puuid: `puuid-${playerName}-${getRandomInt(1000, 9999)}`,
+  gameName: playerName,
   tagLine: TAGS[getRandomInt(0, 4)],
   teamId,
   partyId: `party-${getRandomInt(1, 5)}`,
-  characterId: AGENTS[index],
+  characterId: agent,
   stats: generatePlayerStats(),
   competitiveTier: getRandomInt(15, 25)
 });
 
-// --- LÓGICA PRINCIPAL: Gerar múltiplos arquivos ---
 
-console.log("Iniciando a geração de múltiplos arquivos de partidas...");
+// --- LÓGICA PRINCIPAL ATUALIZADA ---
+console.log("Iniciando a geração de dados de partidas e histórico...");
+const historyList = []; 
 
-// Loop para criar 5 arquivos diferentes
 for (let i = 1; i <= 5; i++) {
   const matchId = `match-${i}`;
-  
-  // 1. Carrega o esqueleto a cada iteração para começar do zero
   const skeletonPath = path.join(__dirname, 'match-details-skeleton.json');
   const matchData = JSON.parse(fs.readFileSync(skeletonPath, 'utf-8'));
 
-  // Atualiza a ID da partida no esqueleto
   matchData.matchInfo.matchId = matchId;
+  matchData.matchInfo.mapId = `/Game/Maps/${MAPS[i-1]}/${MAPS[i-1]}`;
+  matchData.matchInfo.gameLengthMillis = getRandomInt(1800000, 2400000);
 
-  // 2. Gera 10 jogadores com stats aleatórios
+  // MUDANÇA: Embaralha os jogadores e os agentes para esta partida
+  const shuffledPlayers = [...PLAYER_NAMES];
+  const shuffledAgents = [...AGENTS];
+  shuffleArray(shuffledPlayers);
+  shuffleArray(shuffledAgents);
+  
   matchData.players = [];
   for (let p = 0; p < 10; p++) {
     const team = p < 5 ? 'Blue' : 'Red';
-    matchData.players.push(createPlayer(p, team));
+    // Usa os nomes e agentes embaralhados
+    matchData.players.push(createPlayer(shuffledPlayers[p], team, shuffledAgents[p]));
   }
 
-  // 3. Gera resultados de rounds
   matchData.roundResults = [];
   let blueRoundsWon = 0;
   let redRoundsWon = 0;
   while (blueRoundsWon < 13 && redRoundsWon < 13) {
     const winner = Math.random() > 0.5 ? 'Blue' : 'Red';
-    if (winner === 'Blue') blueRoundsWon++;
-    else redRoundsWon++;
+    if (winner === 'Blue') blueRoundsWon++; else redRoundsWon++;
     matchData.roundResults.push({ roundNum: blueRoundsWon + redRoundsWon, winningTeam: winner });
   }
 
-  // 4. Gera dados dos times com base nos rounds
   matchData.teams = [];
   matchData.teams.push({ teamId: 'Blue', won: blueRoundsWon > redRoundsWon, roundsWon: blueRoundsWon, roundsPlayed: blueRoundsWon + redRoundsWon });
   matchData.teams.push({ teamId: 'Red', won: redRoundsWon > blueRoundsWon, roundsWon: redRoundsWon, roundsPlayed: blueRoundsWon + redRoundsWon });
 
-  // 5. Salva o arquivo JSON com o nome da partida (ex: match-1.json)
+  historyList.push({
+    id: matchId,
+    map: MAPS[i-1],
+    result: blueRoundsWon > redRoundsWon ? 'Vitória' : 'Derrota',
+    score: `${blueRoundsWon} - ${redRoundsWon}`,
+    agent: 'Aleatório' // O agente do "nosso" jogador agora é aleatório
+  });
+
   const outputPath = path.join(__dirname, `${matchId}.json`);
   fs.writeFileSync(outputPath, JSON.stringify(matchData, null, 2));
-
-  console.log(`-> Arquivo ${outputPath} gerado com sucesso!`);
+  console.log(`-> Arquivo ${matchId}.json gerado com sucesso!`);
 }
 
-console.log("\nGeração de dados concluída. 5 partidas fictícias foram criadas.");
+const historyPath = path.join(__dirname, 'match-history.json');
+fs.writeFileSync(historyPath, JSON.stringify(historyList, null, 2));
+console.log(`-> Arquivo match-history.json gerado com sucesso!`);
+
+console.log("Geração de dados concluída.");
 


### PR DESCRIPTION
The previous data generation script assigned the same players and agents to every mock match, leading to unrealistic and repetitive simulation data.

This commit introduces a shuffle algorithm to randomize the PLAYER_NAMES and AGENTS arrays for each generated match file. This ensures that every match has a unique team composition, making the frontend simulation more dynamic and realistic.